### PR TITLE
fixes overflow on sidebar control groups

### DIFF
--- a/packages/tesseract-explorer/src/style/PanelQuery.scss
+++ b/packages/tesseract-explorer/src/style/PanelQuery.scss
@@ -23,6 +23,7 @@
     }
 
     .details-content {
+      box-sizing: border-box;
       margin: -5px;
       padding: 5px;
       max-height: 200px;


### PR DESCRIPTION
Adding `box-sizing: border-box;` solved the overflow issue of seeing horizontal scrollbars and the right-hand side being cut off.

**Before**
<img width="311" alt="Screen Shot 2019-07-11 at 12 34 11 PM" src="https://user-images.githubusercontent.com/252276/61068593-68525380-a3d8-11e9-9912-1c103ebe7efc.png">


**After**
<img width="320" alt="Screen Shot 2019-07-11 at 12 34 42 PM" src="https://user-images.githubusercontent.com/252276/61068606-6ee0cb00-a3d8-11e9-8479-6ccbb25b95ab.png">
